### PR TITLE
ci: Switch shellcheck action to also check formatting

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,9 +8,14 @@ on:
 
 jobs:
   shellcheck:
-    name: Shellcheck
+    name: Check shell scripts
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Run ShellCheck
-      uses: ludeeus/action-shellcheck@master
+    - uses: actions/checkout@v3
+    - name: Run sh-checker
+      uses: luizm/action-sh-checker@master
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        sh_checker_only_diff: true
+        sh_checker_comment: true

--- a/getgo
+++ b/getgo
@@ -7,21 +7,8 @@
 # Where the Go toolchain is installed
 BASE_DIR=/opt/go
 
-case $(uname) in
-Linux) OS=linux ;;
-Darwin) OS=darwin ;;
-*)
-	printf 'Unknown OS name: %s\n' "$(uname)" >&2
-	exit 1
-	;;
-esac
-
-case $(uname -m) in
-x86_64) ARCH=amd64 ;;
-arm64) ARCH=arm64 ;;
-arm*) ARCH=armv6l ;;
-aarch64) ARCH=arm64 ;;
-esac
+: "${GETGO_DEBUG:=0}"
+: "${GETGO_DRYRUN:=0}"
 
 #-----------------------------------------------------------------------------
 main() {
@@ -29,13 +16,15 @@ main() {
 	declare -A info
 	local release="${1-stable}"
 
+	checkdeps
+
+	infovars="$(get_latest_info "${release}")"
 	while IFS='=' read -r key value; do
 		info["${key}"]="${value}"
-	done <<<"$(get_latest_info "${release}")"
+	done <<<"${infovars}"
 
 	if ! [[ "${info[version]}" =~ go(.*) ]]; then
-		printf 'Version error: %s\n' "${info[version]}" >&2
-		exit 1
+		errexit 'Version error: %s\n' "${info[version]}"
 	fi
 
 	version="${BASH_REMATCH[1]}"
@@ -47,15 +36,44 @@ main() {
 
 	printf 'Downloading latest %s version %s\n' "${release}" "${version}"
 	mkdir "${install_dir}"
-	curl -sL -o - "https://golang.org/dl/${info[filename]}" |
-		tar -C "${install_dir}" -x -z --strip-components=1
-	ln -nsf "${version}" "${BASE_DIR}/${release}"
+	run curl -sL -o - "https://golang.org/dl/${info[filename]}" |
+		run tar -C "${install_dir}" -x -z --strip-components=1
+	run ln -nsf "${version}" "${BASE_DIR}/${release}"
+}
+
+#-----------------------------------------------------------------------------
+checkdeps() {
+	if ((BASH_VERSINFO[0] < 4)); then
+		errexit 'This script requires bash 4 or later'
+	fi
+
+	if ! which jq >/dev/null 2>&1; then
+		errexit 'jq is required'
+	fi
+
+	if ! which curl >/dev/null 2>&1; then
+		errexit 'curl is required'
+	fi
 }
 
 #-----------------------------------------------------------------------------
 get_latest_info() {
+	local os arch
+	case $(uname) in
+	Linux) os=linux ;;
+	Darwin) os=darwin ;;
+	*) errexit 'Unknown OS name: %s\n' "$(uname)" ;;
+	esac
+
+	case $(uname -m) in
+	x86_64) arch=amd64 ;;
+	arm64 | aarch64) arch=arm64 ;;
+	arm*) arch=armv6l ;;
+	*) errexit 'Unknown architecture: %s\n' "$(uname -m)" ;;
+	esac
+
 	local qp='' select_release=''
-	local select_file="select(.kind == \"archive\" and .os == \"${OS}\" and .arch == \"${ARCH}\")"
+	local select_file="select(.kind == \"archive\" and .os == \"${os}\" and .arch == \"${arch}\")"
 	local to_key_val='to_entries | .[] | .key + "=" + (.value | tostring)'
 
 	case "${1-}" in
@@ -67,14 +85,53 @@ get_latest_info() {
 		select_release='.[0]'
 		;;
 	*)
-		printf 'unknown release type. Must be stable (default) or unstable\n' >&2
-		exit 1
+		errexit 'Unknown release type. Must be stable (default) or unstable\n'
 		;;
 	esac
 
-	curl -sL "https://golang.org/dl/?mode=json${qp}" |
-		jq -r "${select_release} | .files[] | ${select_file} | ${to_key_val}"
+	alwaysrun curl -sL "https://golang.org/dl/?mode=json${qp}" |
+		alwaysrun jq -r "${select_release} | .files[] | ${select_file} | ${to_key_val}" |
+		debug
 }
 
 #-----------------------------------------------------------------------------
-[[ "$(caller)" != 0\ * ]] || main "$@"
+# run runs a command if dry run mode is off, and prints that command to
+# stderr if debug or dry run mode is on.
+run() {
+	if ((GETGO_DEBUG > 0 || GETGO_DRYRUN > 0)); then
+		echo "$@" >&2
+	fi
+	if ((GETGO_DRYRUN > 0)); then
+		return
+	fi
+	"$@"
+}
+
+# alwaysrun runs a command even if dry run mode is on.
+alwaysrun() {
+	if ((GETGO_DEBUG > 0 || GETGO_DRYRUN > 0)); then
+		echo "$@" >&2
+	fi
+	"$@"
+}
+
+# debug sends stdin to stdout, and if debug mode is on, also sends stdin to
+# stderr.
+debug() {
+	if ((GETGO_DEBUG > 0)); then
+		tee /dev/stderr
+	else
+		cat
+	fi
+}
+
+errexit() {
+	# shellcheck disable=SC2059
+	# We want the first arg to be a printf format string.
+	printf "$@" >&2
+	exit 1
+}
+
+#-----------------------------------------------------------------------------
+# Only run main if executed as a script and not sourced.
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then main "$@"; fi

--- a/getgo
+++ b/getgo
@@ -8,68 +8,72 @@
 BASE_DIR=/opt/go
 
 case $(uname) in
-  Linux) OS=linux ;;
-  Darwin) OS=darwin ;;
-  *) printf 'Unknown OS name: %s\n' "$(uname)" >&2; exit 1 ;;
+Linux) OS=linux ;;
+Darwin) OS=darwin ;;
+*)
+	printf 'Unknown OS name: %s\n' "$(uname)" >&2
+	exit 1
+	;;
 esac
 
 case $(uname -m) in
-  x86_64) ARCH=amd64 ;;
-  arm64) ARCH=arm64 ;;
-  arm*) ARCH=armv6l ;;
-  aarch64) ARCH=arm64 ;;
+x86_64) ARCH=amd64 ;;
+arm64) ARCH=arm64 ;;
+arm*) ARCH=armv6l ;;
+aarch64) ARCH=arm64 ;;
 esac
 
 #-----------------------------------------------------------------------------
 main() {
-  set -euo pipefail
-  declare -A info
-  local release="${1-stable}"
+	set -euo pipefail
+	declare -A info
+	local release="${1-stable}"
 
-  while IFS='=' read -r key value; do
-    info["${key}"]="${value}"
-  done <<< "$(get_latest_info "${release}")"
+	while IFS='=' read -r key value; do
+		info["${key}"]="${value}"
+	done <<<"$(get_latest_info "${release}")"
 
-  if ! [[ "${info[version]}" =~ go(.*) ]]; then
-    printf 'Version error: %s\n' "${info[version]}" >&2
-    exit 1
-  fi
+	if ! [[ "${info[version]}" =~ go(.*) ]]; then
+		printf 'Version error: %s\n' "${info[version]}" >&2
+		exit 1
+	fi
 
-  version="${BASH_REMATCH[1]}"
-  install_dir="${BASE_DIR}/${version}"
-  if [[ -e "${install_dir}" ]]; then
-    printf '%s version %s is up to date\n' "${release}" "${version}"
-    exit 0
-  fi
+	version="${BASH_REMATCH[1]}"
+	install_dir="${BASE_DIR}/${version}"
+	if [[ -e "${install_dir}" ]]; then
+		printf '%s version %s is up to date\n' "${release}" "${version}"
+		exit 0
+	fi
 
-  printf 'Downloading latest %s version %s\n' "${release}" "${version}"
-  mkdir "${install_dir}"
-  curl -sL -o - "https://golang.org/dl/${info[filename]}" |
-    tar -C "${install_dir}" -x -z --strip-components=1
-  ln -nsf "${version}" "${BASE_DIR}/${release}"
+	printf 'Downloading latest %s version %s\n' "${release}" "${version}"
+	mkdir "${install_dir}"
+	curl -sL -o - "https://golang.org/dl/${info[filename]}" |
+		tar -C "${install_dir}" -x -z --strip-components=1
+	ln -nsf "${version}" "${BASE_DIR}/${release}"
 }
 
 #-----------------------------------------------------------------------------
 get_latest_info() {
-  local qp='' select_release=''
-  local select_file="select(.kind == \"archive\" and .os == \"${OS}\" and .arch == \"${ARCH}\")"
-  local to_key_val='to_entries | .[] | .key + "=" + (.value | tostring)'
+	local qp='' select_release=''
+	local select_file="select(.kind == \"archive\" and .os == \"${OS}\" and .arch == \"${ARCH}\")"
+	local to_key_val='to_entries | .[] | .key + "=" + (.value | tostring)'
 
-  case "${1-}" in
-    unstable)
-      qp='&include=all'
-      select_release='.[0] | select(.stable | not)'
-      ;;
-    stable | '')
-      select_release='.[0]'
-      ;;
-    *)
-      printf 'unknown release type. Must be stable (default) or unstable\n' >&2
-      exit 1
-  esac
+	case "${1-}" in
+	unstable)
+		qp='&include=all'
+		select_release='.[0] | select(.stable | not)'
+		;;
+	stable | '')
+		select_release='.[0]'
+		;;
+	*)
+		printf 'unknown release type. Must be stable (default) or unstable\n' >&2
+		exit 1
+		;;
+	esac
 
-  curl -sL "https://golang.org/dl/?mode=json${qp}" \
-    | jq -r "${select_release} | .files[] | ${select_file} | ${to_key_val}"
+	curl -sL "https://golang.org/dl/?mode=json${qp}" |
+		jq -r "${select_release} | .files[] | ${select_file} | ${to_key_val}"
 }
 
 #-----------------------------------------------------------------------------

--- a/getgo
+++ b/getgo
@@ -2,6 +2,11 @@
 #
 # Download the binary archive of the latest Go toolchain and install it
 # if it is not already installed.
+#
+# Usage:
+# getgo [stable|prerelease]
+#
+# The default is "stable" if no release specified.
 #-----------------------------------------------------------------------------
 #
 # Where the Go toolchain is installed
@@ -20,11 +25,24 @@ main() {
 
 	infovars="$(get_latest_info "${release}")"
 	while IFS='=' read -r key value; do
+		[[ -n "${key}" ]] || continue
 		info["${key}"]="${value}"
 	done <<<"${infovars}"
 
+	if [[ -z "${info[version]-}" ]]; then
+		if [[ "${release}" == 'prerelease' ]]; then
+			printf 'No prerelease releases available\n'
+			exit 0
+		fi
+		errexit 'No version returned when querying Go download server. Sorry\n'
+	fi
+
+	if [[ -z "${info[filename]-}" ]]; then
+		errexit 'No filename returned by Go download server for version %s. Sorry\n' "${info[version]}"
+	fi
+
 	if ! [[ "${info[version]}" =~ go(.*) ]]; then
-		errexit 'Version error: %s\n' "${info[version]}"
+		errexit 'Unknown version format returned by Go download server: %s\n' "${info[version]}"
 	fi
 
 	version="${BASH_REMATCH[1]}"
@@ -77,7 +95,7 @@ get_latest_info() {
 	local to_key_val='to_entries | .[] | .key + "=" + (.value | tostring)'
 
 	case "${1-}" in
-	unstable)
+	prerelease)
 		qp='&include=all'
 		select_release='.[0] | select(.stable | not)'
 		;;
@@ -85,7 +103,7 @@ get_latest_info() {
 		select_release='.[0]'
 		;;
 	*)
-		errexit 'Unknown release type. Must be stable (default) or unstable\n'
+		errexit 'Unknown release type. Must be "stable" (default) or "prerelease"\n'
 		;;
 	esac
 


### PR DESCRIPTION
Change the GitHub Actions shellcheck action to use
`luizm/action-sh-checker` as that also checks the formatting with
`shfmt`. Set it up so issues are written to the pull request, although I 
may turn this off if it also includes the shfmt diff since I think it is 
useless to put that diff on the PR - formatting is not something you fix 
manually, you just run `shfmt` and be done with it.

Fix up `getgo` since it will fail the formatting check. Align the working
of `getgo` with `getzig` which was made more robust against failures.